### PR TITLE
feat(ci): add qlty coverage upload workflow

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -94,3 +94,31 @@ jobs:
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "All PR validation checks passed." >> $GITHUB_STEP_SUMMARY
+
+  validation-summary:
+    name: Dependency & Standards Validation
+    runs-on: ubuntu-latest
+    needs: [pr-validation-gate]
+    if: always()
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7  # v2.10.1
+        with:
+          egress-policy: audit
+      - name: Check validation gate result
+        env:
+          GATE_RESULT: ${{ needs.pr-validation-gate.result }}
+        run: |
+          echo "## Dependency & Standards Validation" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Check | Result |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| PR Validation Gate | $GATE_RESULT |" >> $GITHUB_STEP_SUMMARY
+          if [ "$GATE_RESULT" != "success" ]; then
+            echo "::error::PR validation gate failed. All checks must pass before merging."
+            exit 1
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "All dependency and standards checks passed." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/qlty.yml
+++ b/.github/workflows/qlty.yml
@@ -1,0 +1,28 @@
+name: Qlty
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+permissions: read-all
+
+concurrency:
+  group: qlty-coverage-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  qlty:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: williaby/.github/.github/workflows/python-qlty-coverage.yml@main
+    permissions:
+      contents: read
+      actions: read
+    with:
+      coverage-artifact-name: coverage-reports
+      coverage-file-path: coverage.xml
+      coverage-format: cobertura
+      workflow-run-id: ${{ github.event.workflow_run.id }}
+    secrets:
+      QLTY_COVERAGE_TOKEN: ${{ secrets.QLTY_COVERAGE_TOKEN }}

--- a/.github/workflows/qlty.yml
+++ b/.github/workflows/qlty.yml
@@ -6,7 +6,9 @@ on:
     types:
       - completed
 
-permissions: read-all
+permissions:
+  contents: read
+  actions: read
 
 concurrency:
   group: qlty-coverage-${{ github.event.workflow_run.head_branch }}
@@ -15,7 +17,7 @@ concurrency:
 jobs:
   qlty:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    uses: williaby/.github/.github/workflows/python-qlty-coverage.yml@main
+    uses: williaby/.github/.github/workflows/python-qlty-coverage.yml@e8fc83c98c2971ad1ece71573d28171463e30c16
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
Upload test coverage to Qlty Cloud after each successful CI run. Requires `QLTY_COVERAGE_TOKEN` secret to be set per-repo at https://qlty.sh/settings/tokens -- the workflow gracefully skips if the token is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated quality-assurance workflow that runs after successful CI, forwards coverage artifact details and a coverage token to a reusable coverage job, and uses branch-based concurrency to avoid duplicate runs.
  * Added a PR validation-summary job that always runs after the gate and writes a clear “Dependency & Standards Validation” section to the PR summary, failing when checks do not pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->